### PR TITLE
Remove default config file from apache

### DIFF
--- a/sql-injection/image_www/Dockerfile
+++ b/sql-injection/image_www/Dockerfile
@@ -4,6 +4,7 @@ ARG WWWDir=/var/www/SQL_Injection
 
 COPY Code $WWWDir
 COPY sql_injection.conf  /etc/apache2/sites-available
+RUN rm /etc/apache2/sites-available/000-default.conf
 RUN  a2ensite sql_injection.conf 
 
 


### PR DESCRIPTION
This commits removes the default 000-default.conf
file from apache2 config directory (/etc/apache2/sites-available)
that was preventing the correct web page from being displayed.